### PR TITLE
Add YAML metadata to generated markdowns

### DIFF
--- a/utils/processador_pje_integrado.py
+++ b/utils/processador_pje_integrado.py
@@ -275,13 +275,20 @@ class ProcessadorPJeIntegrado:
                 texto_md = self.converter_pdf_para_markdown(doc['caminho'], doc['nome_documento'])
                 nome_md = doc['arquivo'].replace('.pdf', '.md')
                 caminho_md = os.path.join(pasta_markdowns, nome_md)
+                front_matter = [
+                    "---",
+                    f"arquivo: '{doc['arquivo']}'",
+                    f"id_documento: '{doc['id_documento']}'",
+                    f"nome_documento: '{doc['nome_documento']}'",
+                    f"paginas: '{doc['paginas_range']}'",
+                    f"paginas_count: {doc['paginas_count']}",
+                    "ocr: 'PaddleOCR (Português)'",
+                    "---",
+                    "",
+                ]
                 with open(caminho_md, 'w', encoding='utf-8') as f:
+                    f.write("\n".join(front_matter))
                     f.write(f"# {doc['nome_documento']}\n\n")
-                    f.write(f"**Arquivo:** {doc['arquivo']}\n\n")
-                    f.write(f"**ID Documento:** {doc['id_documento']}\n\n")
-                    f.write(f"**Páginas:** {doc['paginas_range']} ({doc['paginas_count']} páginas)\n\n")
-                    f.write(f"**OCR:** PaddleOCR (Português)\n\n")
-                    f.write("---\n\n")
                     f.write(texto_md)
                 doc['caminho_markdown'] = caminho_md
                 self.documentos_processados.append(doc)


### PR DESCRIPTION
## Summary
- include YAML front matter when creating Markdown files from separated PDFs

## Testing
- `python test_backend.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686542692bbc8328b5fdcc3571436059